### PR TITLE
kill long running queries before creating/dropping triggers

### DIFF
--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -124,7 +124,6 @@ module Lhm
           AND INFO NOT LIKE "%INFORMATION_SCHEMA.PROCESSLIST%"
           AND TIME > 10 ORDER BY TIME DESC
       SQL
-      # we can log the queries getting killed here
       result.to_a.compact
     end
 

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -3,7 +3,6 @@
 
 require 'lhm/command'
 require 'lhm/sql_helper'
-require 'timeout'
 
 module Lhm
   class Entangler

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -106,6 +106,7 @@ module Lhm
     end
 
     def kill_long_running_queries_on_origin_table!
+      return unless ENV['LHM_KILL_LONG_RUNNING_QUERIES'] == 'true'
       3.times do
         long_running_query_ids(@origin.name).each { |id| @connection.execute("KILL #{id}") }
         sleep(7)

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -9,7 +9,7 @@ module Lhm
     include Command
     include SqlHelper
 
-    TABLES_WITH_LONG_QUERIES = %w(campaigns campaign_roots tags orders).freeze
+    TABLES_WITH_LONG_QUERIES = %w(designs campaigns campaign_roots tags orders).freeze
 
     attr_reader :connection
 
@@ -104,8 +104,9 @@ module Lhm
     end
 
     def kill_long_running_queries_on_origin_table!
-      long_running_query_ids(@origin.name).each do |id|
-        @connection.execute("KILL #{id}")
+      3.times do
+        long_running_query_ids(@origin.name).each { |id| @connection.execute("KILL #{id}") }
+        sleep(7)
       end
     end
 

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -94,7 +94,6 @@ describe Lhm::Entangler do
 
             puts "spawning threads to spam queries..."
             query_spawning_thread = Thread.new do
-              n = 0
               loop do
                 sleep(Random.rand(1.5))
                 trd = Thread.new do
@@ -102,7 +101,6 @@ describe Lhm::Entangler do
                   connection.execute('select sleep(1000) from `origin`;')
                 end
                 threads << trd
-                n += 1
               end
             end
             threads << query_spawning_thread
@@ -150,7 +148,6 @@ describe Lhm::Entangler do
 
             puts "spawning threads to spam queries..."
             query_spawning_thread = Thread.new do
-              n = 0
               loop do
                 sleep(Random.rand(1.5))
                 trd = Thread.new do
@@ -158,7 +155,6 @@ describe Lhm::Entangler do
                   connection.execute('select sleep(1000) from `origin`;')
                 end
                 threads << trd
-                n += 1
               end
             end
             threads << query_spawning_thread

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -92,7 +92,7 @@ describe Lhm::Entangler do
           begin
             threads = []
 
-            puts "spawinging threads to spam queries..."
+            puts "spawning threads to spam queries..."
             query_spawning_thread = Thread.new do
               n = 0
               loop do
@@ -148,7 +148,7 @@ describe Lhm::Entangler do
           begin
             threads = []
 
-            puts "spawinging threads to spam queries..."
+            puts "spawning threads to spam queries..."
             query_spawning_thread = Thread.new do
               n = 0
               loop do

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -6,11 +6,12 @@ require File.expand_path(File.dirname(__FILE__)) + '/integration_helper'
 require 'lhm/table'
 require 'lhm/migration'
 require 'lhm/entangler'
+require 'pry'
 
 describe Lhm::Entangler do
   include IntegrationHelper
 
-  before(:each) { connect_master! }
+  before(:each) { connect_master!(pool_num: 100) }
 
   describe 'entanglement' do
     before(:each) do
@@ -60,6 +61,138 @@ describe Lhm::Entangler do
 
       slave do
         count(:destination, 'common', 'inserted').must_equal(0)
+      end
+    end
+
+    describe 'entanglement with bombarding long running queries on specific tables' do
+      before(:each) do
+        Lhm::Entangler.const_set('TABLES_WITH_LONG_QUERIES_OLD', Lhm::Entangler::TABLES_WITH_LONG_QUERIES)
+        Lhm::Entangler.const_set('TABLES_WITH_LONG_QUERIES', 'origin')
+        execute("insert into origin (common) values ('inserted')")
+        Lhm::Entangler.const_set('LONG_QUERY_TIME_THRESHOLD_OLD', Lhm::Entangler::LONG_QUERY_TIME_THRESHOLD)
+        Lhm::Entangler.const_set('LONG_QUERY_TIME_THRESHOLD', 3)
+      end
+
+      after(:each) do
+        Lhm::Entangler.const_set('TABLES_WITH_LONG_QUERIES', Lhm::Entangler::TABLES_WITH_LONG_QUERIES_OLD)
+        Lhm::Entangler.const_set('TABLES_WITH_LONG_QUERIES_OLD', nil)
+        Lhm::Entangler.const_set('LONG_QUERY_TIME_THRESHOLD', Lhm::Entangler::LONG_QUERY_TIME_THRESHOLD)
+        Lhm::Entangler.const_set('LONG_QUERY_TIME_THRESHOLD_OLD', nil)
+      end
+
+      describe 'with long running query killing env var enabled' do
+        before do
+          ENV['LHM_KILL_LONG_RUNNING_QUERIES'] = 'true'
+        end
+
+        after do
+          ENV.delete('LHM_KILL_LONG_RUNNING_QUERIES')
+        end
+
+        it 'kills long running queries involving the origin table and does not block trigger related actions' do
+          begin
+            threads = []
+
+            puts "spawinging threads to spam queries..."
+            query_spawning_thread = Thread.new do
+              n = 0
+              loop do
+                sleep(Random.rand(1.5))
+                trd = Thread.new do
+                  connection = ActiveRecord::Base.connection
+                  connection.execute('select sleep(1000) from `origin`;')
+                end
+                threads << trd
+                n += 1
+              end
+            end
+            threads << query_spawning_thread
+
+            puts "attempting trigger actions with bombarding queries..."
+            @entangler.run do
+              trigger_count = execute("select count(*) from information_schema.triggers where event_object_table = 'origin'").to_a.flatten.first
+              assert_equal trigger_count, 3
+            end
+
+            trigger_count = execute("select count(*) from information_schema.triggers where event_object_table = 'origin'").to_a.flatten.first
+            assert_equal trigger_count, 0
+          ensure
+            query_spawning_thread.terminate
+            puts "stopping query spamming..."
+            sleep(3)
+
+            puts "cleaning up rogue long queries..."
+            ActiveRecord::Base.connection.reconnect!
+            ids = ActiveRecord::Base.connection.execute("select id from information_schema.processlist where info like '\%sleep(1000)%' and time > 1").to_a.flatten
+            ids.each do |id|
+              execute("KILL #{id};")
+            end
+
+            puts 'cleaning up threads...'
+            threads.each do |trd|
+              begin
+                trd.join
+              rescue => e
+                raise e unless e.message =~ /Lost connection to MySQL server/
+              end
+            end
+          end
+        end
+      end
+
+      describe 'without long running query killing env var enabled' do
+        before do
+          ENV.delete('LHM_KILL_LONG_RUNNING_QUERIES')
+        end
+
+        it 'does not kill long running queries involving the origin table' do
+          begin
+            threads = []
+
+            puts "spawinging threads to spam queries..."
+            query_spawning_thread = Thread.new do
+              n = 0
+              loop do
+                sleep(Random.rand(1.5))
+                trd = Thread.new do
+                  connection = ActiveRecord::Base.connection
+                  connection.execute('select sleep(1000) from `origin`;')
+                end
+                threads << trd
+                n += 1
+              end
+            end
+            threads << query_spawning_thread
+
+            sleep(2)
+
+            puts 'attempting trigger actions with bombarding queries'
+            err = assert_raises Lhm::Error do
+              @entangler.run {}
+            end
+            assert_match /Lock wait timeout exceeded/ , err.message
+          ensure
+            query_spawning_thread.terminate
+            puts "stopping query spamming..."
+            sleep(3)
+
+            puts "cleaning up rogue long queries..."
+            ActiveRecord::Base.connection.reconnect!
+            ids = ActiveRecord::Base.connection.execute("select id from information_schema.processlist where info like '\%sleep(1000)%' and time > 1").to_a.flatten
+            ids.each do |id|
+              execute("KILL #{id};")
+            end
+
+            puts 'cleaning up threads...'
+            threads.each do |trd|
+              begin
+                trd.join
+              rescue => e
+                raise e unless e.message =~ /Lost connection to MySQL server/
+              end
+            end
+          end
+        end
       end
     end
   end

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -6,7 +6,6 @@ require File.expand_path(File.dirname(__FILE__)) + '/integration_helper'
 require 'lhm/table'
 require 'lhm/migration'
 require 'lhm/entangler'
-require 'pry'
 
 describe Lhm::Entangler do
   include IntegrationHelper

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -16,16 +16,16 @@ module IntegrationHelper
     @connection
   end
 
-  def connect_master!
-    connect!(3306)
+  def connect_master!(pool_num: nil)
+    connect!(3306, pool_num: pool_num)
   end
 
   def connect_slave!
     connect!(3307)
   end
 
-  def connect!(port)
-    adapter = ar_conn port
+  def connect!(port, pool_num: nil)
+    adapter = ar_conn(port, pool_num: pool_num)
     Lhm.setup(adapter)
     unless defined?(@@cleaned_up)
       Lhm.cleanup(:run)
@@ -34,14 +34,15 @@ module IntegrationHelper
     @connection = adapter
   end
 
-  def ar_conn(port)
+  def ar_conn(port, pool_num: nil)
     ActiveRecord::Base.establish_connection(
       :adapter  => defined?(Mysql2) ? 'mysql2' : 'mysql',
       :host     => '127.0.0.1',
       :database => 'lhm',
       :username => 'root',
       :port     => port,
-      :password => $password
+      :password => $password,
+      :pool     => pool_num || 5
     )
     ActiveRecord::Base.connection
   end


### PR DESCRIPTION
#### Notes
- kills and logs long running queries on the origin table before creating/dropping triggers
- stops and raises an error when creating/dropping triggers take more than 3 seconds (USE `LOCK_WAIT_TIMEOUT`)
- add env var to control the query-killing mechanism (need to pro-actively add in env var)
- ~**[fill me in] unnecessary query killing when trigger finishes real fast**~ (addressed in `Potential Future Direction`)

#### to-do
- [x] add specs
- [x] manual testing
- [x] confirm with @goodgravy @timminkov that we are targeting the correct tables
- [x] James will be thinking about the race condition
- [x] hold off threading approach until James reaches conclusion
- [x] implement logic to address race condition
- [x] move `sleep` to beginning of the block
- [x] do setting/unsetting `SESSION LOCK_WAIT_TIMEOUT` once
- [x] do unsetting in a `ensure` block
- [x] use `minitest` not `rspec`
- [x] set `rails_teespring` to point at this version of lhm `teepsring/lhm`
- [x] **SET ENV VAR ON PROD**
- [x] test migration on `campaigns` to ensure that this PR is working properly (https://github.com/teespring/rails-teespring/pull/17172)

#### Potential Future Direction
- make query killing less aggressive (e.g. only killing 60+ sec queries)
- have (a set amount of) retries for trigger creation (at some point we might get lucky?)
- use `Threadswait` to clean up threads
- in the case that triggers get created successfully, the new thread would still get executed, meaning we will be unnecessarily killing "long running" queries (unnecessarily being the queries that will be killed shouldn't be killed since they aren't blocking triggers from getting created.