### PR TITLE
Allow to resume migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ spec/integration/database.yml
 Gemfile
 gemfiles/vendor
 omg.ponies
+.idea

--- a/lhm.gemspec
+++ b/lhm.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.executables   = ['lhm-kill-queue']
 
-  s.add_development_dependency 'minitest'
+  s.add_development_dependency 'minitest', '5.6'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'activerecord'
   s.add_development_dependency 'mysql'

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -19,7 +19,7 @@ module Lhm
       if @throttler = options[:throttler]
         @throttler.connection = @connection if @throttler.respond_to?(:connection=)
       end
-      @start = options[:start] || select_start
+      @start = options[:start] || ENV['LHM_RESUME_AT']&.to_i || select_start
       @limit = options[:limit] || select_limit
       @printer = options[:printer] || Printer::Percentage.new
     end

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -84,6 +84,8 @@ module Lhm
     end
 
     def before
+      return if ENV['LHM_RESUME_AT'].present?
+
       kill_long_running_queries_on_origin_table! if special_origin?
       with_transaction_timeout do
         entangle.each do |stmt|

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -199,7 +199,7 @@ module Lhm
     end
 
     def execute
-      unless ENV['LHM_RESUME_AT'].present?
+      if ENV['LHM_RESUME_AT'].blank?
         destination_create
         @statements.each do |stmt|
           @connection.execute(tagged(stmt))

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -193,16 +193,19 @@ module Lhm
 
       dest = @origin.destination_name
 
-      if @connection.table_exists?(dest)
+      if @connection.table_exists?(dest) && ENV['LHM_RESUME_AT'].nil?
         error("#{ dest } should not exist; not cleaned up from previous run?")
       end
     end
 
     def execute
-      destination_create
-      @statements.each do |stmt|
-        @connection.execute(tagged(stmt))
+      unless ENV['LHM_RESUME_AT'].present?
+        destination_create
+        @statements.each do |stmt|
+          @connection.execute(tagged(stmt))
+        end
       end
+
       Migration.new(@origin, destination_read, conditions, renames)
     end
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -43,8 +43,10 @@ Follow the manual instructions if you want more control over this process.
 
 Setup the dependency gems
 
-    export BUNDLE_GEMFILE=gemfiles/ar-3.2_mysql2.gemfile
+    export BUNDLE_GEMFILE=gemfiles/ar-4.2_mysql2.gemfile
     bundle install
+    
+**Note:** `bundle install` fails to compile `mysql` gem's native dependencies with Ruby >= 2.4. If you see those errors, try with Ruby 2.3.3 for now.
 
 To run specs in slave mode, set the MASTER_SLAVE=1 when running tests:
 

--- a/spec/fixtures/lhmn_users.ddl
+++ b/spec/fixtures/lhmn_users.ddl
@@ -1,0 +1,15 @@
+CREATE TABLE `lhmn_users` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `reference` int(11) DEFAULT NULL,
+  `username` varchar(255) DEFAULT NULL,
+  `group` varchar(255) DEFAULT 'Superfriends',
+  `created_at` datetime DEFAULT NULL,
+  `comment` varchar(20) DEFAULT NULL,
+  `description` text,
+  `logins` int(12) DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index_users_on_reference` (`reference`),
+  KEY `index_users_on_username_and_created_at` (`username`,`created_at`),
+  KEY `index_with_a_custom_name` (`username`,`group`)
+
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -63,6 +63,23 @@ describe Lhm::Entangler do
       end
     end
 
+    describe 'when the migration is triggered to resume a previous migration that was aborted in the middle' do
+      before do
+        ENV['LHM_RESUME_AT'] = '5'
+      end
+
+      after do
+        ENV.delete('LHM_RESUME_AT')
+      end
+
+      it 'does not create triggers in the origin table because they should have been created in the previous run' do
+        @entangler.run do
+          trigger_count = execute("select count(*) from information_schema.triggers where event_object_table = 'origin'").to_a.flatten.first
+          assert_equal trigger_count, 0
+        end
+      end
+    end
+
     describe 'entanglement with bombarding long running queries on specific tables' do
       before(:each) do
         Lhm::Entangler.const_set('TABLES_WITH_LONG_QUERIES_OLD', Lhm::Entangler::TABLES_WITH_LONG_QUERIES)

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -55,6 +55,10 @@ module IntegrationHelper
     @connection.select_value(*args)
   end
 
+  def select_values(*args)
+    @connection.select_values(*args)
+  end
+
   def execute(*args)
     retries = 10
     begin

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -67,7 +67,7 @@ describe Lhm do
 
         slave do
           count_all(:users).must_equal(6)
-          select_values('SELECT id FROM users').must_equal([5, 6, 7, 8, 9, 10])
+          select_values('SELECT reference FROM users').must_equal([4, 5, 6, 7, 8, 9])
           table_read(:users).columns['logins'].must_equal({
             :type => 'int(12)',
             :is_nullable => 'YES',


### PR DESCRIPTION
## Problem

We have some really long LHM migrations that we need to run in different phases. That means we need to:

- Start a migration
- Abort it
- Start the migration again but starting at a specific id
- repeat until it's completed

LHM currently doesn't support that

## Solution

Given that this issue is time sensitive (we need to complete a big migration within the next 15 days) I implemented a quick hack to allow us to resume migrations. We can do that running the migration again with an ENV var set specifying at which id to resume the process.

When we set `LHM_RESUME_AT` ENV variable we change the behavior to:
- Skip migrated table creation (because we assume that it exists since a previous aborted run)
- Skip trigger's creation (because we assume that it exists since a previous aborted run)
- Setup Chunker to start copying records since the id specified in `LHM_RESUME_AT`