### PR TITLE
Fix missing data bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ ActiveRecord::Base.establish_connection(
 # and migrate
 Lhm.change_table :users do |m|
   m.add_column :arbitrary, "INT(12)"
+  m.add_column :locale, "VARCHAR(2) NOT NULL DEFAULT 'en'"
   m.add_index  [:arbitrary_id, :created_at]
   m.ddl("alter table %s add column flag tinyint(1)" % m.name)
 end

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ActiveRecord 3.2.x and 4.x (mysql and mysql2 adapters).
 
 ## Limitations
 
-Due to the Chunker implementation, Lhm requires that the table to migrate has a
+Due to the Chunker implementation, Lhm requires that the table to migrate has
 a single integer numeric key column called `id`.
 
 Another note about the Chunker, it performs static sized row copies against the `id`

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -27,7 +27,7 @@ module Lhm
     def execute
       return unless @start && @limit
       @next_to_insert = @start
-      while @next_to_insert < @limit || (@start == @limit)
+      while @next_to_insert <= @limit
         stride = @throttler.stride
         affected_rows = @connection.update(copy(bottom, top(stride)))
 


### PR DESCRIPTION
## Problem

During my work of making migrations resumable I've found a bug that causes LHM to skip copying the last row of a table in certain cases

## Solution

Soundcloud's master branch includes a fix for that issue. I backported it to our fork
