### PR TITLE
Prevent infinite lock when completing migrations and LHM.cleanup

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -70,12 +70,12 @@ module Lhm
     end.select { |name| name =~ /^lhmt/ }
 
     if run
-      lhm_triggers.each do |trigger|
-        connection.execute("drop trigger if exists #{trigger}")
-      end
-      lhm_tables.each do |table|
-        connection.execute("drop table if exists #{table}")
-      end
+      statements_to_run = []
+      lhm_triggers.each { |trigger| statements_to_run << SqlHelper.tagged("drop trigger if exists #{trigger}") }
+      lhm_tables.each { |table| statements_to_run << SqlHelper.tagged("drop table if exists #{table}") }
+
+      connection.execute_metadata_locking_statements(statements_to_run)
+
       true
     elsif lhm_tables.empty? && lhm_triggers.empty?
       puts 'Everything is clean. Nothing to do.'

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -96,7 +96,7 @@ module Lhm
     @@connection ||=
       begin
         raise 'Please call Lhm.setup' unless defined?(ActiveRecord)
-        ActiveRecord::Base.connection
+        Lhm::Connection.new(ActiveRecord::Base.connection)
       end
   end
 

--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -15,7 +15,6 @@ module Lhm
     include Command
     RETRY_SLEEP_TIME = 10
     MAX_RETRIES = 600
-    SESSION_WAIT_LOCK_TIMEOUT = 14
 
     attr_reader :connection, :retries
     attr_writer :max_retries, :retry_sleep_time

--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -53,7 +53,7 @@ module Lhm
     def execute
       begin
         tagged_statements = statements.map { |s| SqlHelper.tagged(s) }
-        @connection.execute_metadata_locking_statements(tagged_statements, @origin)
+        @connection.execute_metadata_locking_statements(tagged_statements, killing_queries_on: @origin)
       rescue ActiveRecord::StatementInvalid => error
         if should_retry_exception?(error) && (@retries += 1) < @max_retries
           sleep(@retry_sleep_time)

--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -52,11 +52,8 @@ module Lhm
 
     def execute
       begin
-        @connection.with_transaction_timeout do
-          statements.each do |stmt|
-            @connection.execute(SqlHelper.tagged(stmt))
-          end
-        end
+        tagged_statements = statements.map { |s| SqlHelper.tagged(s) }
+        @connection.execute_metadata_locking_statements(tagged_statements, @origin)
       rescue ActiveRecord::StatementInvalid => error
         if should_retry_exception?(error) && (@retries += 1) < @max_retries
           sleep(@retry_sleep_time)

--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -52,7 +52,7 @@ module Lhm
 
     def execute
       begin
-        with_transaction_timeout do
+        @connection.with_transaction_timeout do
           statements.each do |stmt|
             @connection.execute(SqlHelper.tagged(stmt))
           end
@@ -66,16 +66,6 @@ module Lhm
           raise
         end
       end
-    end
-
-    def with_transaction_timeout
-      lock_wait_timeout = @connection.select_one("SHOW SESSION VARIABLES LIKE 'LOCK_WAIT_TIMEOUT'")["Value"].to_i
-      @connection.execute("SET SESSION LOCK_WAIT_TIMEOUT=#{SESSION_WAIT_LOCK_TIMEOUT}")
-      Lhm.logger.info "Set transaction timeout (SESSION LOCK_WAIT_TIMEOUT) to #{SESSION_WAIT_LOCK_TIMEOUT} seconds."
-      yield
-    ensure
-      @connection.execute("SET SESSION LOCK_WAIT_TIMEOUT=#{lock_wait_timeout}")
-      Lhm.logger.info "Set transaction timeout (SESSION LOCK_WAIT_TIMEOUT) back to #{lock_wait_timeout} seconds."
     end
 
     def should_retry_exception?(error)

--- a/lib/lhm/connection.rb
+++ b/lib/lhm/connection.rb
@@ -6,11 +6,11 @@ module Lhm
     SESSION_WAIT_LOCK_TIMEOUT = LONG_QUERY_TIME_THRESHOLD + INITIALIZATION_DELAY + TRIGGER_MAXIMUM_DURATION
     TABLES_WITH_LONG_QUERIES = %w(designs campaigns campaign_roots tags orders).freeze
 
-    def execute_metadata_locking_statements(statements, table, on_error)
-      kill_long_running_queries_on_origin_table!(table)
+    def execute_metadata_locking_statements(statements, table, on_error = nil)
+      kill_long_running_queries(table) if usually_has_long_queries?(table)
       with_transaction_timeout(on_error: on_error) do
         statements.each do |statement|
-          kill_long_running_queries_during_transaction(table) do
+          kill_long_blocking_queries_while_statement_is_running(table) do
             execute(statement)
           end
         end
@@ -18,9 +18,8 @@ module Lhm
     end
 
     def with_transaction_timeout(on_error: nil)
-      lock_wait_timeout = ar_connection.execute("SHOW SESSION VARIABLES WHERE VARIABLE_NAME='LOCK_WAIT_TIMEOUT'").to_a.flatten[1].to_i
-      ar_connection.execute("SET SESSION LOCK_WAIT_TIMEOUT=#{SESSION_WAIT_LOCK_TIMEOUT}")
-      Lhm.logger.info "Set transaction timeout (SESSION LOCK_WAIT_TIMEOUT) to #{SESSION_WAIT_LOCK_TIMEOUT} seconds."
+      lock_wait_timeout = get_session_timeout
+      set_session_timeout(SESSION_WAIT_LOCK_TIMEOUT)
       yield
     rescue => e
       if on_error.present?
@@ -33,15 +32,45 @@ module Lhm
         raise
       end
     ensure
-      ar_connection.execute("SET SESSION LOCK_WAIT_TIMEOUT=#{lock_wait_timeout}")
-      Lhm.logger.info "Set transaction timeout (SESSION LOCK_WAIT_TIMEOUT) back to #{lock_wait_timeout} seconds."
+      set_session_timeout(lock_wait_timeout)
     end
 
-    def kill_long_running_queries_on_origin_table!(table, connection: nil)
-      return unless killing_queries_enabled? && usually_has_long_queries?(table)
+    private
+
+    def ar_connection
+      __getobj__
+    end
+
+    def get_session_timeout
+      ar_connection.select_one("SHOW SESSION VARIABLES LIKE 'LOCK_WAIT_TIMEOUT'")["Value"].to_i
+    end
+
+    def set_session_timeout(new_timeout)
+      ar_connection.execute("SET SESSION LOCK_WAIT_TIMEOUT=#{new_timeout}")
+      Lhm.logger.info "Set transaction timeout (SESSION LOCK_WAIT_TIMEOUT) to #{new_timeout} seconds."
+    end
+
+    def kill_long_blocking_queries_while_statement_is_running(table)
+      t = Thread.new do
+        if killing_queries_enabled?
+          # the goal of this thread is to kill queries on the table specified that may be blocking metadata_lock
+          # adquisition. These queries started before the current metadata locking statement started
+          # We delay query killing to confirm the statement we want to protect got actually blocked.
+          sleep(LONG_QUERY_TIME_THRESHOLD + INITIALIZATION_DELAY)
+          new_connection = ActiveRecord::Base.connection
+
+          kill_long_running_queries(table, connection: new_connection)
+        end
+      end
+      yield
+      t.join
+    end
+
+    def kill_long_running_queries(table, connection: nil)
+      return unless killing_queries_enabled?
 
       connection ||= ar_connection
-      long_running_queries(table.name, connection: connection).each do |id, query, duration|
+      long_running_queries(table.name, connection).each do |id, query, duration|
         Lhm.logger.info "Action on table #{table.name} detected; killing #{duration}-second query: #{query}."
         begin
           connection.execute("KILL #{id};")
@@ -55,22 +84,6 @@ module Lhm
       end
     end
 
-    def kill_long_running_queries_during_transaction(table)
-      t = Thread.new do
-        if killing_queries_enabled?
-          # the goal of this thread is to wait until long running queries that started between
-          # #kill_long_running_queries_on_origin_table! and trigger creation
-          # to pass the threshold time and then kill them
-          sleep(LONG_QUERY_TIME_THRESHOLD + INITIALIZATION_DELAY)
-          new_connection = ActiveRecord::Base.connection
-
-          kill_long_running_queries_on_origin_table!(table, connection: new_connection)
-        end
-      end
-      yield
-      t.join
-    end
-
     def killing_queries_enabled?
       ENV['LHM_KILL_LONG_RUNNING_QUERIES'] == 'true'
     end
@@ -79,8 +92,7 @@ module Lhm
       TABLES_WITH_LONG_QUERIES.include? table.name
     end
 
-    def long_running_queries(table_name, connection: nil)
-      connection ||= ar_connection
+    def long_running_queries(table_name, connection)
       result = connection.execute <<-SQL.strip_heredoc
         SELECT ID, INFO, TIME FROM INFORMATION_SCHEMA.PROCESSLIST
         WHERE command <> 'Sleep'
@@ -90,12 +102,6 @@ module Lhm
           AND TIME > '#{LONG_QUERY_TIME_THRESHOLD}'
       SQL
       result.to_a.compact
-    end
-
-    private
-
-    def ar_connection
-      __getobj__
     end
   end
 end

--- a/lib/lhm/connection.rb
+++ b/lib/lhm/connection.rb
@@ -1,0 +1,82 @@
+module Lhm
+  class Connection < SimpleDelegator
+    LONG_QUERY_TIME_THRESHOLD = 10
+    INITIALIZATION_DELAY = 2
+    TRIGGER_MAXIMUM_DURATION = 2
+    SESSION_WAIT_LOCK_TIMEOUT = LONG_QUERY_TIME_THRESHOLD + INITIALIZATION_DELAY + TRIGGER_MAXIMUM_DURATION
+    TABLES_WITH_LONG_QUERIES = %w(designs campaigns campaign_roots tags orders).freeze
+
+    def with_transaction_timeout(on_error:)
+      lock_wait_timeout = ar_connection.execute("SHOW SESSION VARIABLES WHERE VARIABLE_NAME='LOCK_WAIT_TIMEOUT'").to_a.flatten[1].to_i
+      ar_connection.execute("SET SESSION LOCK_WAIT_TIMEOUT=#{SESSION_WAIT_LOCK_TIMEOUT}")
+      Lhm.logger.info "Set transaction timeout (SESSION LOCK_WAIT_TIMEOUT) to #{SESSION_WAIT_LOCK_TIMEOUT} seconds."
+      yield
+    rescue => e
+      if e.message =~ /Lock wait timeout exceeded/
+        on_error.call("Transaction took more than #{SESSION_WAIT_LOCK_TIMEOUT} seconds (SESSION_WAIT_LOCK_TIMEOUT) to run.. ABORT! #{e.message}")
+      else
+        on_error.call(e.message)
+      end
+    ensure
+      ar_connection.execute("SET SESSION LOCK_WAIT_TIMEOUT=#{lock_wait_timeout}")
+      Lhm.logger.info "Set transaction timeout (SESSION LOCK_WAIT_TIMEOUT) back to #{lock_wait_timeout} seconds."
+    end
+
+    def kill_long_running_queries_on_origin_table!(table, connection: nil)
+      return unless ENV['LHM_KILL_LONG_RUNNING_QUERIES'] == 'true' && special_origin?(table)
+
+      connection ||= ar_connection
+      long_running_queries(table.name, connection: connection).each do |id, query, duration|
+        Lhm.logger.info "Action on table #{table.name} detected; killing #{duration}-second query: #{query}."
+        begin
+          connection.execute("KILL #{id};")
+        rescue => e
+          if e.message =~ /Unknown thread id/
+            Lhm.logger.info "Race condition detected. Process to kill no longer exists. Proceeding despite the following error: #{e.message}"
+          else
+            raise e
+          end
+        end
+      end
+    end
+
+    def kill_long_running_queries_during_transaction(table)
+      t = Thread.new do
+        if ENV['LHM_KILL_LONG_RUNNING_QUERIES'] == 'true'
+          # the goal of this thread is to wait until long running queries that started between
+          # #kill_long_running_queries_on_origin_table! and trigger creation
+          # to pass the threshold time and then kill them
+          sleep(LONG_QUERY_TIME_THRESHOLD + INITIALIZATION_DELAY)
+          new_connection = ActiveRecord::Base.connection
+
+          kill_long_running_queries_on_origin_table!(table, connection: new_connection)
+        end
+      end
+      yield
+      t.join
+    end
+
+    def special_origin?(table)
+      TABLES_WITH_LONG_QUERIES.include? table.name
+    end
+
+    def long_running_queries(table_name, connection: nil)
+      connection ||= ar_connection
+      result = connection.execute <<-SQL.strip_heredoc
+        SELECT ID, INFO, TIME FROM INFORMATION_SCHEMA.PROCESSLIST
+        WHERE command <> 'Sleep'
+          AND INFO LIKE '%`#{table_name}`%'
+          AND INFO NOT LIKE '%TRIGGER%'
+          AND INFO NOT LIKE "%INFORMATION_SCHEMA.PROCESSLIST%"
+          AND TIME > '#{LONG_QUERY_TIME_THRESHOLD}'
+      SQL
+      result.to_a.compact
+    end
+
+    private
+
+    def ar_connection
+      __getobj__
+    end
+  end
+end

--- a/lib/lhm/connection.rb
+++ b/lib/lhm/connection.rb
@@ -33,7 +33,7 @@ module Lhm
       kill_long_running_queries(table) if usually_has_long_queries?(table)
       with_custom_metadata_lock_wait_timeout(on_error: on_error) do
         statements.each do |statement|
-          kill_long_blocking_queries_while_statement_is_running(table) do
+          kill_long_blocking_queries_while_statement_is_blocked(table) do
             execute(statement)
           end
         end
@@ -57,7 +57,7 @@ module Lhm
       Lhm.logger.info "Set transaction timeout (SESSION LOCK_WAIT_TIMEOUT) to #{new_timeout} seconds."
     end
 
-    def kill_long_blocking_queries_while_statement_is_running(table)
+    def kill_long_blocking_queries_while_statement_is_blocked(table)
       t = Thread.new do
         if killing_queries_enabled?
           # the goal of this thread is to kill queries on the table specified that may be blocking metadata_lock

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -82,13 +82,21 @@ module Lhm
 
       statements_to_entangle_tables = entangle.map { |statement| tagged(statement) }
 
-      @connection.execute_metadata_locking_statements(statements_to_entangle_tables, @origin, ->(message) { error(message) })
+      @connection.execute_metadata_locking_statements(
+        statements_to_entangle_tables,
+        killing_queries_on: @origin,
+        on_error: ->(message) { error(message) }
+      )
     end
 
     def after
       statements_to_untangle_tables = untangle.map { |statement| tagged(statement) }
 
-      @connection.execute_metadata_locking_statements(statements_to_untangle_tables, @origin, ->(message) { error(message) })
+      @connection.execute_metadata_locking_statements(
+        statements_to_untangle_tables,
+        killing_queries_on: @origin,
+        on_error: ->(message) { error(message) }
+      )
     end
 
     def revert

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -9,12 +9,6 @@ module Lhm
     include Command
     include SqlHelper
 
-    TABLES_WITH_LONG_QUERIES = %w(designs campaigns campaign_roots tags orders).freeze
-    LONG_QUERY_TIME_THRESHOLD = 10
-    INITIALIZATION_DELAY = 2
-    TRIGGER_MAXIMUM_DURATION = 2
-    SESSION_WAIT_LOCK_TIMEOUT = LONG_QUERY_TIME_THRESHOLD + INITIALIZATION_DELAY + TRIGGER_MAXIMUM_DURATION
-
     attr_reader :connection
 
     # Creates entanglement between two tables. All creates, updates and deletes
@@ -86,10 +80,10 @@ module Lhm
     def before
       return if ENV['LHM_RESUME_AT'].present?
 
-      kill_long_running_queries_on_origin_table! if special_origin?
-      with_transaction_timeout do
+      @connection.kill_long_running_queries_on_origin_table!(@origin)
+      @connection.with_transaction_timeout(on_error: ->(message) { error(message) }) do
         entangle.each do |stmt|
-          kill_long_running_queries_during_transaction do
+          @connection.kill_long_running_queries_during_transaction(@origin) do
             @connection.execute(tagged(stmt))
           end
         end
@@ -97,10 +91,10 @@ module Lhm
     end
 
     def after
-      kill_long_running_queries_on_origin_table! if special_origin?
-      with_transaction_timeout do
+      @connection.kill_long_running_queries_on_origin_table!(@origin)
+      @connection.with_transaction_timeout(on_error: ->(message) { error(message) }) do
         untangle.each do |stmt|
-          kill_long_running_queries_during_transaction do
+          @connection.kill_long_running_queries_during_transaction(@origin) do
             @connection.execute(tagged(stmt))
           end
         end
@@ -109,72 +103,6 @@ module Lhm
 
     def revert
       after
-    end
-
-    def special_origin?
-      TABLES_WITH_LONG_QUERIES.include? @origin.name
-    end
-
-    def kill_long_running_queries_on_origin_table!(connection: nil)
-      return unless ENV['LHM_KILL_LONG_RUNNING_QUERIES'] == 'true'
-      connection ||= @connection
-      long_running_queries(@origin.name, connection: connection).each do |id, query, duration|
-        Lhm.logger.info "Action on table #{@origin.name} detected; killing #{duration}-second query: #{query}."
-        begin
-          connection.execute("KILL #{id};")
-        rescue => e
-          if e.message =~ /Unknown thread id/
-            Lhm.logger.info "Race condition detected. Process to kill no longer exists. Proceeding despite the following error: #{e.message}"
-          else
-            raise e
-          end
-        end
-      end
-    end
-
-    def long_running_queries(table_name, connection: nil)
-      connection ||= @connection
-      result = connection.execute <<-SQL.strip_heredoc
-        SELECT ID, INFO, TIME FROM INFORMATION_SCHEMA.PROCESSLIST
-        WHERE command <> 'Sleep'
-          AND INFO LIKE '%`#{table_name}`%'
-          AND INFO NOT LIKE '%TRIGGER%'
-          AND INFO NOT LIKE "%INFORMATION_SCHEMA.PROCESSLIST%"
-          AND TIME > '#{LONG_QUERY_TIME_THRESHOLD}'
-      SQL
-      result.to_a.compact
-    end
-
-    def kill_long_running_queries_during_transaction
-      t = Thread.new do
-        if ENV['LHM_KILL_LONG_RUNNING_QUERIES'] == 'true'
-          # the goal of this thread is to wait until long running queries that started between
-          # #kill_long_running_queries_on_origin_table! and trigger creation
-          # to pass the threshold time and then kill them
-          sleep(LONG_QUERY_TIME_THRESHOLD + INITIALIZATION_DELAY)
-          new_connection = ActiveRecord::Base.connection
-
-          kill_long_running_queries_on_origin_table!(connection: new_connection)
-        end
-      end
-      yield
-      t.join
-    end
-
-    def with_transaction_timeout
-      lock_wait_timeout = @connection.execute("SHOW SESSION VARIABLES WHERE VARIABLE_NAME='LOCK_WAIT_TIMEOUT'").to_a.flatten[1].to_i
-      @connection.execute("SET SESSION LOCK_WAIT_TIMEOUT=#{SESSION_WAIT_LOCK_TIMEOUT}")
-      Lhm.logger.info "Set transaction timeout (SESSION LOCK_WAIT_TIMEOUT) to #{SESSION_WAIT_LOCK_TIMEOUT} seconds."
-      yield
-    rescue => e
-      if e.message =~ /Lock wait timeout exceeded/
-        error("Transaction took more than #{SESSION_WAIT_LOCK_TIMEOUT} seconds (SESSION_WAIT_LOCK_TIMEOUT) to run.. ABORT! #{e.message}")
-      else
-        error(e.message)
-      end
-    ensure
-      @connection.execute("SET SESSION LOCK_WAIT_TIMEOUT=#{lock_wait_timeout}")
-      Lhm.logger.info "Set transaction timeout (SESSION LOCK_WAIT_TIMEOUT) back to #{lock_wait_timeout} seconds."
     end
 
     private

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -25,7 +25,7 @@ describe Lhm::AtomicSwitcher do
       Thread.abort_on_exception = false
     end
 
-    it 'should complete without needing retries when it was waiting for locks for less than current session timeout time' do
+    it 'should complete without needing retries when it was waiting for locks for less than current session timeout' do
       skip 'This spec only works with mysql2' unless defined? Mysql2
 
       without_verbose do

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -82,9 +82,8 @@ describe Lhm, 'cleanup' do
           Lhm.cleanup(:run).must_equal(true)
           Lhm.cleanup.must_equal(true)
           fail 'no exception was raised'
-        rescue => e
-          assert e.is_a?(ActiveRecord::StatementInvalid)
-          assert_match /Lock wait timeout exceeded/ , e.message
+        rescue ActiveRecord::StatementInvalid => e
+          assert_match /Lock wait timeout exceeded/, e.message
         ensure
           locking_thread.join
         end

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -82,18 +82,18 @@ describe Lhm::Entangler do
 
     describe 'entanglement with bombarding long running queries on specific tables' do
       before(:each) do
-        Lhm::Entangler.const_set('TABLES_WITH_LONG_QUERIES_OLD', Lhm::Entangler::TABLES_WITH_LONG_QUERIES)
-        Lhm::Entangler.const_set('TABLES_WITH_LONG_QUERIES', 'origin')
+        Lhm::Connection.const_set('TABLES_WITH_LONG_QUERIES_OLD', Lhm::Connection::TABLES_WITH_LONG_QUERIES)
+        Lhm::Connection.const_set('TABLES_WITH_LONG_QUERIES', 'origin')
         execute("insert into origin (common) values ('inserted')")
-        Lhm::Entangler.const_set('LONG_QUERY_TIME_THRESHOLD_OLD', Lhm::Entangler::LONG_QUERY_TIME_THRESHOLD)
-        Lhm::Entangler.const_set('LONG_QUERY_TIME_THRESHOLD', 3)
+        Lhm::Connection.const_set('LONG_QUERY_TIME_THRESHOLD_OLD', Lhm::Connection::LONG_QUERY_TIME_THRESHOLD)
+        Lhm::Connection.const_set('LONG_QUERY_TIME_THRESHOLD', 3)
       end
 
       after(:each) do
-        Lhm::Entangler.const_set('TABLES_WITH_LONG_QUERIES', Lhm::Entangler::TABLES_WITH_LONG_QUERIES_OLD)
-        Lhm::Entangler.const_set('TABLES_WITH_LONG_QUERIES_OLD', nil)
-        Lhm::Entangler.const_set('LONG_QUERY_TIME_THRESHOLD', Lhm::Entangler::LONG_QUERY_TIME_THRESHOLD)
-        Lhm::Entangler.const_set('LONG_QUERY_TIME_THRESHOLD_OLD', nil)
+        Lhm::Connection.const_set('TABLES_WITH_LONG_QUERIES', Lhm::Connection::TABLES_WITH_LONG_QUERIES_OLD)
+        Lhm::Connection.const_set('TABLES_WITH_LONG_QUERIES_OLD', nil)
+        Lhm::Connection.const_set('LONG_QUERY_TIME_THRESHOLD', Lhm::Connection::LONG_QUERY_TIME_THRESHOLD)
+        Lhm::Connection.const_set('LONG_QUERY_TIME_THRESHOLD_OLD', nil)
       end
 
       def long_running_query

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -85,15 +85,11 @@ describe Lhm::Entangler do
         Lhm::Connection.const_set('TABLES_WITH_LONG_QUERIES_OLD', Lhm::Connection::TABLES_WITH_LONG_QUERIES)
         Lhm::Connection.const_set('TABLES_WITH_LONG_QUERIES', 'origin')
         execute("insert into origin (common) values ('inserted')")
-        Lhm::Connection.const_set('LONG_QUERY_TIME_THRESHOLD_OLD', Lhm::Connection::LONG_QUERY_TIME_THRESHOLD)
-        Lhm::Connection.const_set('LONG_QUERY_TIME_THRESHOLD', 3)
       end
 
       after(:each) do
         Lhm::Connection.const_set('TABLES_WITH_LONG_QUERIES', Lhm::Connection::TABLES_WITH_LONG_QUERIES_OLD)
         Lhm::Connection.const_set('TABLES_WITH_LONG_QUERIES_OLD', nil)
-        Lhm::Connection.const_set('LONG_QUERY_TIME_THRESHOLD', Lhm::Connection::LONG_QUERY_TIME_THRESHOLD)
-        Lhm::Connection.const_set('LONG_QUERY_TIME_THRESHOLD_OLD', nil)
       end
 
       def long_running_query

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -117,7 +117,8 @@ module IntegrationHelper
         conn.query("BEGIN")
         conn.query("select * from `#{table.name}` for update;")
         queue.push(true)
-        conn.query("select sleep(1000); -- `#{table.name}`")
+        conn.query("select sleep(#{connection.metadata_lock_wait_timeout + 2}); -- `#{table.name}`")
+        conn.query("ROLLBACK")
       rescue Mysql2::Error => error
         raise unless error.message =~ /Lost connection to MySQL server during query/
       end

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -45,7 +45,12 @@ module IntegrationHelper
       :password => $password,
       :pool     => pool_num || 5
     )
-    Lhm::Connection.new(ActiveRecord::Base.connection)
+    Lhm::Connection.new(
+      ActiveRecord::Base.connection,
+      long_query_threshold: 1,
+      statement_initialization_delay: 2,
+      max_statement_duration: 2
+    )
   end
 
   def select_one(*args)

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -5,6 +5,7 @@ require 'yaml'
 require 'active_support'
 $password = YAML.load_file(File.expand_path(File.dirname(__FILE__)) + '/database.yml')['password'] rescue nil
 
+require 'lhm/connection'
 require 'lhm/table'
 require 'lhm/sql_helper'
 
@@ -44,7 +45,7 @@ module IntegrationHelper
       :password => $password,
       :pool     => pool_num || 5
     )
-    ActiveRecord::Base.connection
+    Lhm::Connection.new(ActiveRecord::Base.connection)
   end
 
   def select_one(*args)

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -178,7 +178,7 @@ module IntegrationHelper
       show indexes in `#{ table_name }`
      where key_name = '#{ key_name }'
        and non_unique = #{ non_unique }
-                 >)
+    >)
   end
 
   #


### PR DESCRIPTION
## Problem

Every time we need to perform DDL queries on a table we need to get a `metadata_lock`. If a query is running on that table, that lock can't be acquired. Given that MySQL's default `lock_wait_timeout` is too long (1 year) we can get into a situation where the whole DB gets stuck causing a major outage of the platform.

## Solution

Reuse logic that we added to LHM's entangler to run DDL operations in a safe way. This process includes 3 steps:

- If the affected table usually has long queries (> 10 seconds), kill them
- Set `lock_wait_timeout` for the current DB connection to something shorter (14 seconds)
- Start DDL statement
- Kill any long queries that may be blocking the DDL statement to let it continue
- If the DDL statement is still blocked, we will get a timeout within 14 seconds without causing major issues to the platform

## Summary of changes

I had to do a couple of refactors to be able to reuse the logic an improve a bit the tests. The most important things to consider are:

- Extract common logic to safely run a DDL statement into a separate class. I modeled this as a special connection that knows how to deal with these issues
- Reuse that logic in the `atomic_switcher`. This is the class that performs the final step on an LHM migration: replacing the old table with the new one
- Reuse part of that logic in `LHM.cleanup` process. That process is triggered by a person, so it's enough to protect the platform and avoid trying to kill long queries. In an ideal world, it would be great to reuse query killing logic there too, but I had to refactor more code to be able to do that, so I just added basic safety there.
- Cleanup tests a bit to simplify the way to use different timeouts for tests (to make them run a bit faster)