### PR TITLE
FUL-802 Fix ID column validation error

### DIFF
--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -17,7 +17,7 @@ module Lhm
 
     def satisfies_id_column_requirement?
       !!((id = columns['id']) &&
-        id[:type] =~ /(bigint|int)\(\d+\)/)
+        id[:type] =~ /(bigint|int)/)
     end
 
     def destination_name


### PR DESCRIPTION
## What
We recently upgraded `rails-teespring`'s database to MySQL v8.0.33. When running a migration after the upgrade, LHM is throwing this error:

```
Lhm::Error: origin does not satisfy `id` key requirements
```

## Changes
- remove validation of display width from ID column type

## JIRA Ticket
[FUL-802](https://amazesw.atlassian.net/browse/FUL-802)

## Rollback
Revert PR

[FUL-802]: https://amazesw.atlassian.net/browse/FUL-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ